### PR TITLE
Fix: lucide-react icon import error in ScenarioEditor

### DIFF
--- a/src/components/editor/ScenarioEditor.tsx
+++ b/src/components/editor/ScenarioEditor.tsx
@@ -11,8 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
 import { Separator } from '@/components/ui/separator'
 import { 
-  Sidebar, 
-  SidebarLeft, 
+  PanelLeft, 
   Eye, 
   EyeOff, 
   Save,
@@ -190,7 +189,7 @@ export function ScenarioEditor() {
                 size="sm"
                 onClick={toggleLeftSidebar}
               >
-                <SidebarLeft className="h-4 w-4" />
+                <PanelLeft className="h-4 w-4" />
               </Button>
               
               <Separator orientation="vertical" className="h-4" />


### PR DESCRIPTION
This PR fixes a bug where an incorrect icon name (`SidebarLeft`) was being imported from `lucide-react` in the `ScenarioEditor.tsx` component, causing a runtime error.

Changes:
- Replaced `SidebarLeft` import with the correct `PanelLeft` icon.
- Removed unused `Sidebar` import from `lucide-react`.
- Updated the usage of the icon in the JSX to `<PanelLeft />`.

This resolves the "module does not provide an export named 'SidebarLeft'" error.

Generated with [Claude Code](https://claude.ai/code)